### PR TITLE
fix: skip unreachable VPN servers fast via DNS pre-check

### DIFF
--- a/src/vpn.py
+++ b/src/vpn.py
@@ -1,4 +1,6 @@
 import os
+import random
+import socket
 import subprocess
 import time
 from pathlib import Path
@@ -8,6 +10,26 @@ import httpx
 from httpx import AsyncHTTPTransport, HTTPTransport, Request, Response
 
 from src.config.logger import logger
+
+
+def extract_hostname_from_ovpn(config_file_path: str | Path) -> str | None:
+    """Extract the hostname from the 'remote' directive of an .ovpn file."""
+    with open(config_file_path, encoding="utf-8") as f:
+        for line in f:
+            if line.strip().startswith("remote "):
+                parts = line.strip().split()
+                if len(parts) >= 2:
+                    return parts[1]
+    return None
+
+
+def check_hostname_resolution(hostname: str) -> bool:
+    """Check if a hostname can be resolved via DNS."""
+    try:
+        socket.getaddrinfo(hostname, None)
+        return True
+    except (socket.gaierror, OSError):
+        return False
 
 
 class Vpn:
@@ -38,20 +60,30 @@ class Vpn:
         self.check_interval = check_interval
         self.start_periodic_check()
 
-    def connect(self):
+    def connect(self) -> bool:
         if self._disabled:
             logger.warning("VPN connection is disabled. No configuration provided.")
-            return
+            return False
 
-        tries = 0
-        while tries < 3:
-            self.vpn_process = connect_to_vpn(self.config_file_path)
-            public_ip = self.get_public_ip()
-            if public_ip and public_ip != self.host_ip:
-                logger.info("Connected to VPN with public IP: %s", public_ip)
-                return True
-            tries += 1
-            time.sleep(5)
+        if not self.config_file_path:
+            return False
+
+        hostname = extract_hostname_from_ovpn(self.config_file_path)
+        if hostname and not check_hostname_resolution(hostname):
+            logger.warning(
+                "DNS resolution failed for %s (config: %s). Skipping.",
+                hostname,
+                self.config_file_path,
+            )
+            return False
+
+        self.vpn_process = connect_to_vpn(self.config_file_path)
+        public_ip = self.get_public_ip()
+        if public_ip and public_ip != self.host_ip:
+            logger.info("Connected to VPN with public IP: %s", public_ip)
+            return True
+
+        return False
 
     def rotate(self):
         if self._disabled:
@@ -196,9 +228,9 @@ def kill_vpn():
 
 def get_ovpn_files(folder_path: str | Path) -> list[Path]:
     folder_path = Path(folder_path)
-    # Use glob to get all files with the .ovpn extension
-    ovpn_files = folder_path.glob("*.ovpn")
-    return list(ovpn_files)
+    ovpn_files = list(folder_path.glob("*.ovpn"))
+    random.shuffle(ovpn_files)
+    return ovpn_files
 
 
 class NameSolver:

--- a/vpn_configs/Windscribe-Adelaide-Lofty.ovpn
+++ b/vpn_configs/Windscribe-Adelaide-Lofty.ovpn
@@ -7,7 +7,7 @@ verify-x509-name adl-354.windscribe.com name
 nobind
 auth-user-pass
 
-resolv-retry infinite
+resolv-retry 5
 
 cipher AES-256-GCM
 ncp-ciphers AES-256-GCM:AES-256-CBC:AES-128-GCM

--- a/vpn_configs/Windscribe-Adelaide-Oval.ovpn
+++ b/vpn_configs/Windscribe-Adelaide-Oval.ovpn
@@ -7,7 +7,7 @@ verify-x509-name adl-319.windscribe.com name
 nobind
 auth-user-pass
 
-resolv-retry infinite
+resolv-retry 5
 
 cipher AES-256-GCM
 ncp-ciphers AES-256-GCM:AES-256-CBC:AES-128-GCM

--- a/vpn_configs/Windscribe-Amsterdam-Bicycle.ovpn
+++ b/vpn_configs/Windscribe-Amsterdam-Bicycle.ovpn
@@ -7,7 +7,7 @@ verify-x509-name ams-229.windscribe.com name
 nobind
 auth-user-pass
 
-resolv-retry infinite
+resolv-retry 5
 
 cipher AES-256-GCM
 ncp-ciphers AES-256-GCM:AES-256-CBC:AES-128-GCM

--- a/vpn_configs/Windscribe-Amsterdam-RedLight.ovpn
+++ b/vpn_configs/Windscribe-Amsterdam-RedLight.ovpn
@@ -7,7 +7,7 @@ verify-x509-name ams-289.windscribe.com name
 nobind
 auth-user-pass
 
-resolv-retry infinite
+resolv-retry 5
 
 cipher AES-256-GCM
 ncp-ciphers AES-256-GCM:AES-256-CBC:AES-128-GCM

--- a/vpn_configs/Windscribe-Amsterdam-Stroopwafel.ovpn
+++ b/vpn_configs/Windscribe-Amsterdam-Stroopwafel.ovpn
@@ -7,7 +7,7 @@ verify-x509-name ams-120.windscribe.com name
 nobind
 auth-user-pass
 
-resolv-retry infinite
+resolv-retry 5
 
 cipher AES-256-GCM
 ncp-ciphers AES-256-GCM:AES-256-CBC:AES-128-GCM

--- a/vpn_configs/Windscribe-Amsterdam-Tulip.ovpn
+++ b/vpn_configs/Windscribe-Amsterdam-Tulip.ovpn
@@ -7,7 +7,7 @@ verify-x509-name ams-193.windscribe.com name
 nobind
 auth-user-pass
 
-resolv-retry infinite
+resolv-retry 5
 
 cipher AES-256-GCM
 ncp-ciphers AES-256-GCM:AES-256-CBC:AES-128-GCM

--- a/vpn_configs/Windscribe-Ashdod-YamPark.ovpn
+++ b/vpn_configs/Windscribe-Ashdod-YamPark.ovpn
@@ -7,7 +7,7 @@ verify-x509-name tlv-218.windscribe.com name
 nobind
 auth-user-pass
 
-resolv-retry infinite
+resolv-retry 5
 
 cipher AES-256-GCM
 ncp-ciphers AES-256-GCM:AES-256-CBC:AES-128-GCM

--- a/vpn_configs/Windscribe-Athens-Agora.ovpn
+++ b/vpn_configs/Windscribe-Athens-Agora.ovpn
@@ -7,7 +7,7 @@ verify-x509-name ath-312.windscribe.com name
 nobind
 auth-user-pass
 
-resolv-retry infinite
+resolv-retry 5
 
 cipher AES-256-GCM
 ncp-ciphers AES-256-GCM:AES-256-CBC:AES-128-GCM

--- a/vpn_configs/Windscribe-Athens-Odeon.ovpn
+++ b/vpn_configs/Windscribe-Athens-Odeon.ovpn
@@ -7,7 +7,7 @@ verify-x509-name ath-247.windscribe.com name
 nobind
 auth-user-pass
 
-resolv-retry infinite
+resolv-retry 5
 
 cipher AES-256-GCM
 ncp-ciphers AES-256-GCM:AES-256-CBC:AES-128-GCM

--- a/vpn_configs/Windscribe-Atlanta-Mountain.ovpn
+++ b/vpn_configs/Windscribe-Atlanta-Mountain.ovpn
@@ -7,7 +7,7 @@ verify-x509-name atl-109.windscribe.com name
 nobind
 auth-user-pass
 
-resolv-retry infinite
+resolv-retry 5
 
 cipher AES-256-GCM
 ncp-ciphers AES-256-GCM:AES-256-CBC:AES-128-GCM

--- a/vpn_configs/Windscribe-Atlanta-Piedmont.ovpn
+++ b/vpn_configs/Windscribe-Atlanta-Piedmont.ovpn
@@ -7,7 +7,7 @@ verify-x509-name atl-331.windscribe.com name
 nobind
 auth-user-pass
 
-resolv-retry infinite
+resolv-retry 5
 
 cipher AES-256-GCM
 ncp-ciphers AES-256-GCM:AES-256-CBC:AES-128-GCM

--- a/vpn_configs/Windscribe-Auckland-Hauraki.ovpn
+++ b/vpn_configs/Windscribe-Auckland-Hauraki.ovpn
@@ -7,7 +7,7 @@ verify-x509-name akl-352.windscribe.com name
 nobind
 auth-user-pass
 
-resolv-retry infinite
+resolv-retry 5
 
 cipher AES-256-GCM
 ncp-ciphers AES-256-GCM:AES-256-CBC:AES-128-GCM

--- a/vpn_configs/Windscribe-Auckland-Parnell.ovpn
+++ b/vpn_configs/Windscribe-Auckland-Parnell.ovpn
@@ -7,7 +7,7 @@ verify-x509-name akl-251.windscribe.com name
 nobind
 auth-user-pass
 
-resolv-retry infinite
+resolv-retry 5
 
 cipher AES-256-GCM
 ncp-ciphers AES-256-GCM:AES-256-CBC:AES-128-GCM

--- a/vpn_configs/Windscribe-Bangkok-Lumphini.ovpn
+++ b/vpn_configs/Windscribe-Bangkok-Lumphini.ovpn
@@ -7,7 +7,7 @@ verify-x509-name bkk-415.windscribe.com name
 nobind
 auth-user-pass
 
-resolv-retry infinite
+resolv-retry 5
 
 cipher AES-256-GCM
 ncp-ciphers AES-256-GCM:AES-256-CBC:AES-128-GCM

--- a/vpn_configs/Windscribe-Barcelona-Batllo.ovpn
+++ b/vpn_configs/Windscribe-Barcelona-Batllo.ovpn
@@ -7,7 +7,7 @@ verify-x509-name bcn-239.windscribe.com name
 nobind
 auth-user-pass
 
-resolv-retry infinite
+resolv-retry 5
 
 cipher AES-256-GCM
 ncp-ciphers AES-256-GCM:AES-256-CBC:AES-128-GCM

--- a/vpn_configs/Windscribe-Belgrade-Rakia.ovpn
+++ b/vpn_configs/Windscribe-Belgrade-Rakia.ovpn
@@ -7,7 +7,7 @@ verify-x509-name beg-288.windscribe.com name
 nobind
 auth-user-pass
 
-resolv-retry infinite
+resolv-retry 5
 
 cipher AES-256-GCM
 ncp-ciphers AES-256-GCM:AES-256-CBC:AES-128-GCM

--- a/vpn_configs/Windscribe-Bend-OregonTrail.ovpn
+++ b/vpn_configs/Windscribe-Bend-OregonTrail.ovpn
@@ -7,7 +7,7 @@ verify-x509-name pdx-302.windscribe.com name
 nobind
 auth-user-pass
 
-resolv-retry infinite
+resolv-retry 5
 
 cipher AES-256-GCM
 ncp-ciphers AES-256-GCM:AES-256-CBC:AES-128-GCM

--- a/vpn_configs/Windscribe-Bogota-Rololandia.ovpn
+++ b/vpn_configs/Windscribe-Bogota-Rololandia.ovpn
@@ -7,7 +7,7 @@ verify-x509-name bog-360.windscribe.com name
 nobind
 auth-user-pass
 
-resolv-retry infinite
+resolv-retry 5
 
 cipher AES-256-GCM
 ncp-ciphers AES-256-GCM:AES-256-CBC:AES-128-GCM

--- a/vpn_configs/Windscribe-Boston-Harvard.ovpn
+++ b/vpn_configs/Windscribe-Boston-Harvard.ovpn
@@ -7,7 +7,7 @@ verify-x509-name bos-408.windscribe.com name
 nobind
 auth-user-pass
 
-resolv-retry infinite
+resolv-retry 5
 
 cipher AES-256-GCM
 ncp-ciphers AES-256-GCM:AES-256-CBC:AES-128-GCM

--- a/vpn_configs/Windscribe-Boston-MIT.ovpn
+++ b/vpn_configs/Windscribe-Boston-MIT.ovpn
@@ -7,7 +7,7 @@ verify-x509-name bos-298.windscribe.com name
 nobind
 auth-user-pass
 
-resolv-retry infinite
+resolv-retry 5
 
 cipher AES-256-GCM
 ncp-ciphers AES-256-GCM:AES-256-CBC:AES-128-GCM

--- a/vpn_configs/Windscribe-Bratislava-DevinCastle.ovpn
+++ b/vpn_configs/Windscribe-Bratislava-DevinCastle.ovpn
@@ -7,7 +7,7 @@ verify-x509-name bts-213.windscribe.com name
 nobind
 auth-user-pass
 
-resolv-retry infinite
+resolv-retry 5
 
 cipher AES-256-GCM
 ncp-ciphers AES-256-GCM:AES-256-CBC:AES-128-GCM

--- a/vpn_configs/Windscribe-Brisbane-BadKoala.ovpn
+++ b/vpn_configs/Windscribe-Brisbane-BadKoala.ovpn
@@ -7,7 +7,7 @@ verify-x509-name bne-225.windscribe.com name
 nobind
 auth-user-pass
 
-resolv-retry infinite
+resolv-retry 5
 
 cipher AES-256-GCM
 ncp-ciphers AES-256-GCM:AES-256-CBC:AES-128-GCM

--- a/vpn_configs/Windscribe-Brisbane-GoodKoala.ovpn
+++ b/vpn_configs/Windscribe-Brisbane-GoodKoala.ovpn
@@ -7,7 +7,7 @@ verify-x509-name bne-357.windscribe.com name
 nobind
 auth-user-pass
 
-resolv-retry infinite
+resolv-retry 5
 
 cipher AES-256-GCM
 ncp-ciphers AES-256-GCM:AES-256-CBC:AES-128-GCM

--- a/vpn_configs/Windscribe-Brussels-Guildhouse.ovpn
+++ b/vpn_configs/Windscribe-Brussels-Guildhouse.ovpn
@@ -7,7 +7,7 @@ verify-x509-name bru-99.windscribe.com name
 nobind
 auth-user-pass
 
-resolv-retry infinite
+resolv-retry 5
 
 cipher AES-256-GCM
 ncp-ciphers AES-256-GCM:AES-256-CBC:AES-128-GCM

--- a/vpn_configs/Windscribe-Bucharest-NoVampires.ovpn
+++ b/vpn_configs/Windscribe-Bucharest-NoVampires.ovpn
@@ -7,7 +7,7 @@ verify-x509-name otp-105.windscribe.com name
 nobind
 auth-user-pass
 
-resolv-retry infinite
+resolv-retry 5
 
 cipher AES-256-GCM
 ncp-ciphers AES-256-GCM:AES-256-CBC:AES-128-GCM

--- a/vpn_configs/Windscribe-Budapest-Danube.ovpn
+++ b/vpn_configs/Windscribe-Budapest-Danube.ovpn
@@ -7,7 +7,7 @@ verify-x509-name bud-90.windscribe.com name
 nobind
 auth-user-pass
 
-resolv-retry infinite
+resolv-retry 5
 
 cipher AES-256-GCM
 ncp-ciphers AES-256-GCM:AES-256-CBC:AES-128-GCM

--- a/vpn_configs/Windscribe-BuenosAires-Tango.ovpn
+++ b/vpn_configs/Windscribe-BuenosAires-Tango.ovpn
@@ -7,7 +7,7 @@ verify-x509-name eze-278.windscribe.com name
 nobind
 auth-user-pass
 
-resolv-retry infinite
+resolv-retry 5
 
 cipher AES-256-GCM
 ncp-ciphers AES-256-GCM:AES-256-CBC:AES-128-GCM

--- a/vpn_configs/Windscribe-London-Biscuits.ovpn
+++ b/vpn_configs/Windscribe-London-Biscuits.ovpn
@@ -7,7 +7,7 @@ verify-x509-name lhr-335.windscribe.com name
 nobind
 auth-user-pass
 
-resolv-retry infinite
+resolv-retry 5
 
 cipher AES-256-GCM
 ncp-ciphers AES-256-GCM:AES-256-CBC:AES-128-GCM

--- a/vpn_configs/Windscribe-London-Crumpets.ovpn
+++ b/vpn_configs/Windscribe-London-Crumpets.ovpn
@@ -7,7 +7,7 @@ verify-x509-name lhr-171.windscribe.com name
 nobind
 auth-user-pass
 
-resolv-retry infinite
+resolv-retry 5
 
 cipher AES-256-GCM
 ncp-ciphers AES-256-GCM:AES-256-CBC:AES-128-GCM

--- a/vpn_configs/Windscribe-London-Custard.ovpn
+++ b/vpn_configs/Windscribe-London-Custard.ovpn
@@ -7,7 +7,7 @@ verify-x509-name lhr-341.windscribe.com name
 nobind
 auth-user-pass
 
-resolv-retry infinite
+resolv-retry 5
 
 cipher AES-256-GCM
 ncp-ciphers AES-256-GCM:AES-256-CBC:AES-128-GCM

--- a/vpn_configs/Windscribe-LosAngeles-Cube.ovpn
+++ b/vpn_configs/Windscribe-LosAngeles-Cube.ovpn
@@ -7,7 +7,7 @@ verify-x509-name lax-321.windscribe.com name
 nobind
 auth-user-pass
 
-resolv-retry infinite
+resolv-retry 5
 
 cipher AES-256-GCM
 ncp-ciphers AES-256-GCM:AES-256-CBC:AES-128-GCM

--- a/vpn_configs/Windscribe-LosAngeles-Dogg.ovpn
+++ b/vpn_configs/Windscribe-LosAngeles-Dogg.ovpn
@@ -7,7 +7,7 @@ verify-x509-name lax-107.windscribe.com name
 nobind
 auth-user-pass
 
-resolv-retry infinite
+resolv-retry 5
 
 cipher AES-256-GCM
 ncp-ciphers AES-256-GCM:AES-256-CBC:AES-128-GCM

--- a/vpn_configs/Windscribe-LosAngeles-Lamar.ovpn
+++ b/vpn_configs/Windscribe-LosAngeles-Lamar.ovpn
@@ -7,7 +7,7 @@ verify-x509-name lax-310.windscribe.com name
 nobind
 auth-user-pass
 
-resolv-retry infinite
+resolv-retry 5
 
 cipher AES-256-GCM
 ncp-ciphers AES-256-GCM:AES-256-CBC:AES-128-GCM

--- a/vpn_configs/Windscribe-Luxembourg-Chemin.ovpn
+++ b/vpn_configs/Windscribe-Luxembourg-Chemin.ovpn
@@ -7,7 +7,7 @@ verify-x509-name lux-152.windscribe.com name
 nobind
 auth-user-pass
 
-resolv-retry infinite
+resolv-retry 5
 
 cipher AES-256-GCM
 ncp-ciphers AES-256-GCM:AES-256-CBC:AES-128-GCM

--- a/vpn_configs/Windscribe-Madrid-PlazaMayor.ovpn
+++ b/vpn_configs/Windscribe-Madrid-PlazaMayor.ovpn
@@ -7,7 +7,7 @@ verify-x509-name mad-427.windscribe.com name
 nobind
 auth-user-pass
 
-resolv-retry infinite
+resolv-retry 5
 
 cipher AES-256-GCM
 ncp-ciphers AES-256-GCM:AES-256-CBC:AES-128-GCM

--- a/vpn_configs/Windscribe-Madrid-Prado.ovpn
+++ b/vpn_configs/Windscribe-Madrid-Prado.ovpn
@@ -7,7 +7,7 @@ verify-x509-name mad-115.windscribe.com name
 nobind
 auth-user-pass
 
-resolv-retry infinite
+resolv-retry 5
 
 cipher AES-256-GCM
 ncp-ciphers AES-256-GCM:AES-256-CBC:AES-128-GCM

--- a/vpn_configs/Windscribe-Paris-Jardin.ovpn
+++ b/vpn_configs/Windscribe-Paris-Jardin.ovpn
@@ -7,7 +7,7 @@ verify-x509-name cdg-342.windscribe.com name
 nobind
 auth-user-pass
 
-resolv-retry infinite
+resolv-retry 5
 
 cipher AES-256-GCM
 ncp-ciphers AES-256-GCM:AES-256-CBC:AES-128-GCM

--- a/vpn_configs/Windscribe-Paris-Seine.ovpn
+++ b/vpn_configs/Windscribe-Paris-Seine.ovpn
@@ -7,7 +7,7 @@ verify-x509-name cdg-103.windscribe.com name
 nobind
 auth-user-pass
 
-resolv-retry infinite
+resolv-retry 5
 
 cipher AES-256-GCM
 ncp-ciphers AES-256-GCM:AES-256-CBC:AES-128-GCM


### PR DESCRIPTION
Servers with unresolvable hostnames (e.g. ams-229.whiskergalaxy.com) caused 90s+ hangs per attempt due to resolv-retry infinite and a 3x same-config retry loop. Now: DNS is checked before connecting, broken configs are skipped in <1s, server order is randomized, and OpenVPN gives up DNS after 5s as a safety net.