### PR TITLE
Fix: namesolver dynamic dns

### DIFF
--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,5 @@
 beautifulsoup4
+dnspython
 httpx
 playwright
 psycopg2-binary

--- a/src/store_products_remote.py
+++ b/src/store_products_remote.py
@@ -119,8 +119,8 @@ async def main(partial_store: str | None = None):
 
 
 async def make_request_get(session, product_id: float) -> Any:
-    # Get product details
-    response = await session.get(API_URL_TEMPLATE.format(id=transform_id(product_id)))
+    # Get product details   
+    response = await session.get(API_URL_TEMPLATE.format(id=transform_id(product_id)), timeout=5.0)
     logger.info("Request product %s: Status Code - %s", product_id, response.status_code)
     return response.json()
 

--- a/src/store_products_remote.py
+++ b/src/store_products_remote.py
@@ -119,7 +119,7 @@ async def main(partial_store: str | None = None):
 
 
 async def make_request_get(session, product_id: float) -> Any:
-    # Get product details   
+    # Get product details
     response = await session.get(API_URL_TEMPLATE.format(id=transform_id(product_id)), timeout=5.0)
     logger.info("Request product %s: Status Code - %s", product_id, response.status_code)
     return response.json()

--- a/src/vpn.py
+++ b/src/vpn.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from threading import Thread
 
 import dns.resolver
-
 import httpx
 from httpx import AsyncHTTPTransport, HTTPTransport, Request, Response
 
@@ -248,7 +247,8 @@ class NameSolver:
                 answer = self._resolver.resolve(name, "A")
                 return str(answer[0])
             except dns.exception.DNSException as exc:
-                logger.warning("DNS resolution failed for %s: %s. Falling back to system DNS.", name, exc)
+                msg = f"DNS resolution failed for {name}: {exc}. Falling back to system DNS."
+                logger.warning(msg)
         return ""
 
     def resolve(self, request: Request) -> Request:

--- a/src/vpn.py
+++ b/src/vpn.py
@@ -6,6 +6,8 @@ import time
 from pathlib import Path
 from threading import Thread
 
+import dns.resolver
+
 import httpx
 from httpx import AsyncHTTPTransport, HTTPTransport, Request, Response
 
@@ -235,9 +237,14 @@ def get_ovpn_files(folder_path: str | Path) -> list[Path]:
 
 class NameSolver:
     # https://github.com/encode/httpx/issues/1444
+    _PUBLIC_NAMESERVERS = ["8.8.8.8", "8.8.4.4"]
+
     def get(self, name: str) -> str:
         if name.endswith(".mercadona.es"):
-            return "96.16.88.179"
+            resolver = dns.resolver.Resolver()
+            resolver.nameservers = self._PUBLIC_NAMESERVERS
+            answer = resolver.resolve(name, "A")
+            return str(answer[0])
         return ""
 
     def resolve(self, request: Request) -> Request:

--- a/src/vpn.py
+++ b/src/vpn.py
@@ -237,14 +237,18 @@ def get_ovpn_files(folder_path: str | Path) -> list[Path]:
 
 class NameSolver:
     # https://github.com/encode/httpx/issues/1444
-    _PUBLIC_NAMESERVERS = ["8.8.8.8", "8.8.4.4"]
+    def __init__(self) -> None:
+        self._resolver = dns.resolver.Resolver()
+        self._resolver.nameservers = ["8.8.8.8", "8.8.4.4"]
+        self._resolver.lifetime = 5.0
 
     def get(self, name: str) -> str:
         if name.endswith(".mercadona.es"):
-            resolver = dns.resolver.Resolver()
-            resolver.nameservers = self._PUBLIC_NAMESERVERS
-            answer = resolver.resolve(name, "A")
-            return str(answer[0])
+            try:
+                answer = self._resolver.resolve(name, "A")
+                return str(answer[0])
+            except dns.exception.DNSException as exc:
+                logger.warning("DNS resolution failed for %s: %s. Falling back to system DNS.", name, exc)
         return ""
 
     def resolve(self, request: Request) -> Request:


### PR DESCRIPTION
## Problem

`NameSolver` had a hardcoded IP (`96.16.88.179`) for `*.mercadona.es` hosts. This IP was stale, causing `ConnectTimeout` on every request when using the `AsyncCustomHost` transport — while a plain `httpx.get()` bypassing the custom transport worked fine.

## Solution

Replace the hardcoded IP with a dynamic DNS resolution via Google's public nameservers (`8.8.8.8` / `8.8.4.4`), bypassing VPN DNS which may not resolve `.mercadona.es` correctly. The `sni_hostname` extension still ensures TLS SNI sends the original hostname.

## Changes

- `src/vpn.py` — `NameSolver.get()` now resolves via `dns.resolver` with public nameservers instead of returning a hardcoded IP
- `requirements/requirements.txt` — added `dnspython`
- `src/store_products_remote.py` — removed leftover `breakpoint()`